### PR TITLE
Handle ProtectedError in DestroyModelMixin

### DIFF
--- a/drftoolbox/viewsets.py
+++ b/drftoolbox/viewsets.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+    drftoolbox.viewsets
+    ~~~~~~~~~~~~~~~~~~~
+
+    This module defines viewset and classes and mixins used by the API
+
+    :copyright: (c) 2019 by Medical Decisions LLC
+"""
+from django.db.models.deletion import ProtectedError
+from rest_framework import mixins, serializers
+from rest_framework.viewsets import GenericViewSet
+
+
+class DestroyModelMixin(mixins.DestroyModelMixin):
+    """
+    Destroy a model instance.  Raise a validation error if a ProtectedError is raised by a database constraint.
+    """
+
+    def perform_destroy(self, instance):
+        try:
+            instance.delete()
+        except ProtectedError as e:
+            msg = 'Referenced by protected {} {}'.format(
+                e.protected_objects.model._meta.label,
+                ', '.join([str(x) for x in e.protected_objects.values_list('id', flat=True)])
+            )
+            raise serializers.ValidationError(msg)
+
+
+class ModelViewSet(mixins.CreateModelMixin,
+                   mixins.RetrieveModelMixin,
+                   mixins.UpdateModelMixin,
+                   DestroyModelMixin,
+                   mixins.ListModelMixin,
+                   GenericViewSet):
+    """
+    A viewset that provides default `create()`, `retrieve()`, `update()`, `partial_update()`, `destroy()` and `list()`
+    actions.  This class incorporates system-wide customizations of the basic DRF viewet behavior; in this case, uses
+    our DestroyModelMixin.
+    """
+    pass

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import pytest
+from unittest.mock import Mock
+
+from django.db.models.deletion import ProtectedError
+from rest_framework.serializers import ValidationError
+
+from drftoolbox.viewsets import DestroyModelMixin
+
+
+class TestDestroyModelMixin:
+
+    def test_perform_destroy_raises_for_protectederror(self):
+        protected = Mock()
+        protected.model._meta.label = 'testmodel'
+        protected.values_list.return_value = [1, 2]
+        exception = ProtectedError('some db constraint', protected_objects=protected)
+        exception.protected_objects = protected
+
+        instance = Mock()
+        instance.delete.side_effect=exception
+
+        with pytest.raises(ValidationError) as exc:
+            DestroyModelMixin().perform_destroy(instance)
+            assert exc.message == 'Referenced by protected testmodel 1, 2'
+
+        assert instance.delete.call_count == 1
+
+    def test_perform_destroy_passes(self):
+        instance = Mock()
+        DestroyModelMixin().perform_destroy(instance)
+        assert instance.delete.call_count == 1


### PR DESCRIPTION
Add DestroyModelMixin which raises a ValidationError for a ProtectedError (which happens when a db constraint references existing records).

From https://github.com/DoctorDecisions/ContentService/blob/development/libs/extensions/viewsets.py, and needed now by https://github.com/DoctorDecisions/Service/issues/1477