### PR TITLE
updating acceptable method to take claims and header

### DIFF
--- a/drftoolbox/authentication.py
+++ b/drftoolbox/authentication.py
@@ -263,7 +263,7 @@ class BaseOpenIdJWTAuthentication(authentication.BaseAuthentication):
                 'acceptable_issuers(claims, header)'
             )
             warnings.warn(msg, DeprecationWarning)
-            issuers = self.acceptable_issuers()
+            issuers = self.acceptable_issuers()  # pylint: disable=no-value-for-parameter
         else:
             issuers = self.acceptable_issuers(claims, header)
 
@@ -274,7 +274,7 @@ class BaseOpenIdJWTAuthentication(authentication.BaseAuthentication):
                 'with acceptable_issuers(claims, header)'
             )
             warnings.warn(msg, DeprecationWarning)
-            audiences = self.acceptable_audiences(claims)
+            audiences = self.acceptable_audiences(claims)  # pylint: disable=no-value-for-parameter
         else:
             audiences = self.acceptable_audiences(claims, header)
 

--- a/drftoolbox/utils.py
+++ b/drftoolbox/utils.py
@@ -8,11 +8,13 @@
     :copyright: (c) 2018 by Medical Decisions LLC
 """
 import copy
+import inspect
+import warnings
 
 from django.http import Http404, HttpResponseNotFound
-from django.urls import resolve, reverse
+from django.urls import resolve
 from django.utils.http import urlencode
-from rest_framework import request as drf_request, viewsets
+from rest_framework import viewsets
 
 
 def inline_render(method, url, request, query_dict=None, accepts=None):
@@ -61,3 +63,19 @@ def inline_render(method, url, request, query_dict=None, accepts=None):
         return resp
     except Http404:
         return HttpResponseNotFound()
+
+
+def valid_func_args(func, *args):
+    """
+    Helper function to test that a function's parameters match the desired
+    signature, if not then issue a deprecation warning.
+    """
+    keys = inspect.signature(func).parameters.keys()
+    if set(args) == set(keys):
+        return True
+    msg = (
+        f'{func.__name__}({", ".join(keys)}) is deprecated, please override '
+        f'with {func.__name__}({", ".join(args)})'
+    )
+    warnings.warn(msg, DeprecationWarning)
+    return False

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -24,10 +24,10 @@ class TestOpenIdJWTAuthentication(authentication.BaseOpenIdJWTAuthentication):
         except get_user_model().DoesNotExist:
             return None
 
-    def acceptable_issuers(self):
+    def acceptable_issuers(self, claims, header):
         return ['issuer']
 
-    def acceptable_audiences(self, payload):
+    def acceptable_audiences(self, claims, header):
         return ['audience1', 'audience2']
 
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -18,7 +18,7 @@ from drftoolbox import authentication
 
 
 class TestOpenIdJWTAuthentication(authentication.BaseOpenIdJWTAuthentication):
-    def authenticate_credentials(self, payload):
+    def authenticate_credentials(self, payload, request):
         try:
             return get_user_model().objects.get(id=payload.get('user_id'))
         except get_user_model().DoesNotExist:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
-import json
-
 from django.test import TestCase, RequestFactory, override_settings
 from django.contrib.auth import get_user_model
 from django.urls import path
 from rest_framework import views, viewsets, response, request
-from rest_framework.reverse import reverse
+import pytest
 
 from drftoolbox import utils
 
@@ -60,3 +58,14 @@ class InlineRenderTests(TestCase):
     def test_get_for_view(self):
         resp = utils.inline_render('GET', '/test-v/', self.request)
         assert resp.data == {'data': 'test-v'}
+
+
+class TestValidFuncArgs(TestCase):
+    def echo(self, val):
+        return val
+
+    def test_valid_func_args(self):
+        assert utils.valid_func_args(self.echo, 'val') is True
+
+    def test_invalid_func_args(self):
+        pytest.deprecated_call(utils.valid_func_args, self.echo, 'value')


### PR DESCRIPTION
Rewriting the method signatures of `acceptable_audiences` and
`acceptable_issuers` to take both the claims and header values.
Also adding a deprecation warning for old implementations that don't
adhere to the new signature