### PR TITLE
fix for utils.valid_func_args to work with mock

### DIFF
--- a/drftoolbox/utils.py
+++ b/drftoolbox/utils.py
@@ -26,6 +26,9 @@ def inline_render(method, url, request, query_dict=None, accepts=None):
     calling the API view.  This could be useful for say bootstrapping an
     initial API call with other data elements.
     """
+    # the viewsets module references the API settings, thus if you try to
+    # use these utility functions early on (say when you are defining the API
+    # settings) a circular dep error will occur.
     from rest_framework import viewsets
     try:
         resolver = resolve(url)
@@ -73,9 +76,10 @@ def valid_func_args(func, *args):
     keys = inspect.signature(func).parameters.keys()
     if set(args) == set(keys):
         return True
+    label = getattr(func, '__name__', str(func))
     msg = (
-        f'{func.__name__}({", ".join(keys)}) is deprecated, please override '
-        f'with {func.__name__}({", ".join(args)})'
+        f'{label}({", ".join(keys)}) is deprecated, please override '
+        f'with {label}({", ".join(args)})'
     )
     warnings.warn(msg, DeprecationWarning)
     return False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from unittest import mock
+
 from django.test import TestCase, RequestFactory, override_settings
 from django.contrib.auth import get_user_model
 from django.urls import path
@@ -69,3 +71,7 @@ class TestValidFuncArgs(TestCase):
 
     def test_invalid_func_args(self):
         pytest.deprecated_call(utils.valid_func_args, self.echo, 'value')
+
+    def test_mock_func(self):
+        func = mock.MagicMock(return_value=1)
+        pytest.deprecated_call(utils.valid_func_args, func, 'value')


### PR DESCRIPTION
updating the label used in the deprecation message to work with
MagicMock functions, as mocks don't have a `__name__` attribute